### PR TITLE
fix boucle infinie.

### DIFF
--- a/src/main/java/fr/ippon/contest/puissance4/App.java
+++ b/src/main/java/fr/ippon/contest/puissance4/App.java
@@ -20,6 +20,7 @@ public class App {
 					jeu.jouer(col);
 				} catch (Exception e) {
 					System.err.println("Erreur - " + e.getMessage());
+					scanner.next();
 				}
 			}
 			afficherResultat(jeu);


### PR DESCRIPTION
La saisie d'un caractère non-numérique lançait une boucle infinie sur le scanner. Lancer "next()" permet d'ignorer la valeur incriminée.