### PR TITLE
Correction utilisation de "Devoxx"

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ Pour ce faire, vous devrez écrire une classe Puissance4Impl qui implémente l'i
 
 Vous serez évalués sur la cohérence de votre applicatif avec ces spécifications (il doit passer un maximum des tests unitaires fournis – tous étant le niveau recherché), sur la lisibilité du code et sa rapidité d'exécution (le plus petit nombre d'instructions pour évaluer le jeu étant le meilleur). 
 
-Pour soumettre votre réponse, et gagner une place pour le Devoxx, vous devrez nous envoyer le zip généré par la commande 
+Pour soumettre votre réponse, et gagner une place pour Devoxx, vous devrez nous envoyer le zip généré par la commande 
 	mvn package
 par mail à jmcaillaud@ippon.fr


### PR DESCRIPTION
Cf. tweet de l'équipe : https://twitter.com/DevoxxFR/status/572691015783608320